### PR TITLE
画像の表示品質向上のための属性追加

### DIFF
--- a/funya1_wpf/FormAbout.xaml
+++ b/funya1_wpf/FormAbout.xaml
@@ -23,7 +23,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Image x:Name="MineImage" Height="32" Width="32" Source="/Resources/Stand.png"/>
+        <Image x:Name="MineImage" Height="32" Width="32" Source="/Resources/Stand.png" SnapsToDevicePixels="True"/>
         <StackPanel Grid.Column="1" Orientation="Vertical">
             <Label Content="ふにゃ" FontSize="24"/>
             <Label Content="{Binding Version}"/>

--- a/funya1_wpf/FormEditor.xaml
+++ b/funya1_wpf/FormEditor.xaml
@@ -65,7 +65,7 @@
             <ScrollViewer x:Name="StageContainer" Grid.Column="0" HorizontalScrollBarVisibility="Visible" Background="{Binding StageColorBrush}">
                 <Canvas x:Name="StageCanvas" MouseDown="StageCanvas_MouseDown" MouseMove="StageCanvas_MouseMove" Width="320" Height="320">
                     <ContentControl x:Name="PlaceMine">
-                        <Image Height="32" Width="32" Source="/Resources/Stand.png"/>
+                        <Image Height="32" Width="32" Source="/Resources/Stand.png" SnapsToDevicePixels="True"/>
                     </ContentControl>
                     <ContentControl x:Name="PlaceFood1">
                         <Image Height="32" Width="32" Source="/Resources/banana.png"/>
@@ -96,8 +96,8 @@
                     <GroupBox Header="マップチップ">
                         <StackPanel Orientation="Vertical">
                             <Canvas x:Name="ChipContainer" Width="320" Height="32" MouseDown="ChipContainer_MouseDown" MouseMove="ChipContainer_MouseMove">
-                                <Image x:Name="ChipImage" DataContext="{Binding StageData}" Source="{Binding Image}" Stretch="None"/>
-                                <Image x:Name="ChipSelector" Source="/Resources/Selected.png" Stretch="None" Width="32" Height="32"/>
+                                <Image x:Name="ChipImage" DataContext="{Binding StageData}" Source="{Binding Image}" Stretch="None" SnapsToDevicePixels="True"/>
+                                <Image x:Name="ChipSelector" Source="/Resources/Selected.png" Stretch="None" Width="32" Height="32" SnapsToDevicePixels="True"/>
                             </Canvas>
                             <Button Command="{Binding LoadChip_Click}" Content="画像切り替え" Margin="5,5,5,5"/>
                         </StackPanel>
@@ -105,22 +105,22 @@
                     <GroupBox Header="キャラクター" Grid.Row="1">
                         <StackPanel Orientation="Horizontal">
                             <ToggleButton x:Name="SelectMine" Margin="5,5,5,5" Command="{Binding SelectMine_Click}">
-                                <Image Height="32" Width="32" Source="/Resources/Stand.png"/>
+                                <Image Height="32" Width="32" Source="/Resources/Stand.png" SnapsToDevicePixels="True"/>
                             </ToggleButton>
                             <ToggleButton x:Name="SelectFood1" Margin="5,5,5,5" Command="{Binding SelectFood_Click}" CommandParameter="1">
-                                <Image Height="32" Width="32" Source="/Resources/banana.png"/>
+                                <Image Height="32" Width="32" Source="/Resources/banana.png" SnapsToDevicePixels="True"/>
                             </ToggleButton>
                             <ToggleButton x:Name="SelectFood2" Margin="5,5,5,5" Command="{Binding SelectFood_Click}" CommandParameter="2">
-                                <Image Height="32" Width="32" Source="/Resources/banana.png"/>
+                                <Image Height="32" Width="32" Source="/Resources/banana.png" SnapsToDevicePixels="True"/>
                             </ToggleButton>
                             <ToggleButton x:Name="SelectFood3" Margin="5,5,5,5" Command="{Binding SelectFood_Click}" CommandParameter="3">
-                                <Image Height="32" Width="32" Source="/Resources/banana.png"/>
+                                <Image Height="32" Width="32" Source="/Resources/banana.png" SnapsToDevicePixels="True"/>
                             </ToggleButton>
                             <ToggleButton x:Name="SelectFood4" Margin="5,5,5,5" Command="{Binding SelectFood_Click}" CommandParameter="4">
-                                <Image Height="32" Width="32" Source="/Resources/banana.png"/>
+                                <Image Height="32" Width="32" Source="/Resources/banana.png" SnapsToDevicePixels="True"/>
                             </ToggleButton>
                             <ToggleButton x:Name="SelectFood5" Margin="5,5,5,5" Command="{Binding SelectFood_Click}" CommandParameter="5">
-                                <Image Height="32" Width="32" Source="/Resources/banana.png"/>
+                                <Image Height="32" Width="32" Source="/Resources/banana.png" SnapsToDevicePixels="True"/>
                             </ToggleButton>
                             <Button Content="－" Command="{Binding ReduceFood_Click}" Margin="5,5,5,5" x:Name="ReduceFood"/>
                             <Button Content="＋" Command="{Binding AddFood_Click}" Margin="5,5,5,5" x:Name="AddFood"/>

--- a/funya1_wpf/FormMain.xaml
+++ b/funya1_wpf/FormMain.xaml
@@ -83,7 +83,7 @@
         </Menu>
         <Viewbox x:Name="Screen" Grid.Row="1" Height="268" Width="347">
             <Grid>
-                <Canvas x:Name="Client" ClipToBounds="True" Height="268" Width="347" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Canvas x:Name="Client" ClipToBounds="True" Height="268" Width="347" HorizontalAlignment="Center" VerticalAlignment="Center" SnapsToDevicePixels="True">
                     <Canvas x:Name="Stage" Height="153" Width="193" Canvas.Left="10" Canvas.Top="10" ClipToBounds="True">
                         <Image x:Name="Food1" Height="32" Width="32" Canvas.Left="0" Canvas.Top="0" Source="/Resources/banana.png"/>
                         <Image x:Name="Food2" Height="32" Width="32" Canvas.Left="32" Canvas.Top="0" Source="/Resources/banana.png"/>
@@ -102,7 +102,7 @@
                             <ColumnDefinition/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <Image x:Name="MessageImage" Width="32" Height="32" Margin="8,0,8,0" Source="/Resources/Stand.png" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                        <Image x:Name="MessageImage" Width="32" Height="32" Margin="8,0,8,0" Source="/Resources/Stand.png" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center" SnapsToDevicePixels="True"/>
                         <TextBlock x:Name="LabelMsg" FontSize="27.75" Grid.Column="1" VerticalAlignment="Center">ふにゃ</TextBlock>
                         <TextBlock x:Name="LabelSub" Grid.ColumnSpan="3" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="0,0,8,8">補足説明</TextBlock>
                     </Grid>

--- a/funya1_wpf/FormResults.xaml
+++ b/funya1_wpf/FormResults.xaml
@@ -16,7 +16,7 @@
         </Grid.RowDefinitions>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
             <Label Content="とったバナナの数" FontSize="18" VerticalAlignment="Center"/>
-            <Image Height="32" Width="32" Source="/Resources/banana.png" VerticalAlignment="Center"/>
+            <Image Height="32" Width="32" Source="/Resources/banana.png" VerticalAlignment="Center" SnapsToDevicePixels="True"/>
             <Label Content="×" FontSize="18" VerticalAlignment="Center"/>
             <TextBox x:Name="BananaCount" Text="{Binding Results.GetTotal, Mode=OneTime}" FontSize="18" BorderBrush="{x:Null}" VerticalAlignment="Center" Background="{x:Null}" LostFocus="BananaCount_LostFocus" MaxLength="4" MaxLines="2147483643"/>
         </StackPanel>

--- a/funya1_wpf/FormSelectImage.xaml
+++ b/funya1_wpf/FormSelectImage.xaml
@@ -21,7 +21,7 @@
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Vertical">
-                        <Image Source="{Binding Image}"/>
+                        <Image Source="{Binding Image}" SnapsToDevicePixels="True"/>
                         <TextBlock Text="{Binding Title}"/>
                     </StackPanel>
                 </DataTemplate>


### PR DESCRIPTION
複数の XAML ファイルにおいて、`Image` 要素および `Canvas` 要素に `SnapsToDevicePixels="True"` 属性を追加しました。これにより、画像がデバイスのピクセルにスナップされ、表示品質が向上します。具体的な変更は以下の通りです:

* `FormAbout.xaml`: `Image` 要素に `SnapsToDevicePixels="True"` を追加
* `FormEditor.xaml`: 複数の `Image` 要素に `SnapsToDevicePixels="True"` を追加
* `FormMain.xaml`: `Canvas` 要素および `Image` 要素に `SnapsToDevicePixels="True"` を追加
* `FormResults.xaml`: `Image` 要素に `SnapsToDevicePixels="True"` を追加
* `FormSelectImage.xaml`: `Image` 要素に `SnapsToDevicePixels="True"` を追加