### PR TITLE
本体：寝たらBGM音量控えめに

### DIFF
--- a/funya1_wpf/FormMain.xaml.cs
+++ b/funya1_wpf/FormMain.xaml.cs
@@ -36,6 +36,8 @@ namespace funya1_wpf
         private DateTime LastMouseMoved = DateTime.Now;
         private readonly DispatcherTimer? MouseHideTimer = new() { Interval = TimeSpan.FromSeconds(0.5) };
 
+        public readonly DispatcherTimer MusicFadeTimer = new() { Interval = TimeSpan.FromMilliseconds(100) };
+
         public FormMain()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -46,6 +48,16 @@ namespace funya1_wpf
             cleater = new Cleater(this, music, results, options, resources);
             SaveData = new(music, results, options);
             SaveData.Load();
+
+            MusicFadeTimer.Tick += (_, _) =>
+            {
+                if (cleater.GameState == GameState.Playing)
+                {
+                    music.Volume = cleater.Status == Status.Slepping ? Music.SleepVolume : Music.NormalVolume;
+                }
+                music.OnFrame();
+            };
+            MusicFadeTimer.Start();
 
             SetScreenSize(options.ScreenSize);
             WindowState = options.WindowState;
@@ -69,7 +81,7 @@ namespace funya1_wpf
             {
                 if (cleater.GameState == GameState.Playing)
                 {
-                    music.Play(music.Options.Playing);
+                    music.Play(music.Options.Playing, cleater.Status == Status.Slepping ? Music.SleepVolume : Music.NormalVolume);
                 }
             };
         }

--- a/funya1_wpf/Music.cs
+++ b/funya1_wpf/Music.cs
@@ -9,6 +9,11 @@ namespace funya1_wpf
         public MediaPlayer Player = new();
         public MusicInfo? Playing;
 
+        public int Volume { get; set; }
+        public int ActualVolume { get; private set; }
+        public const int NormalVolume = 50;
+        public const int SleepVolume = 10;
+
         public Music()
         {
             Player.MediaEnded += Player_MediaEnded;
@@ -27,14 +32,17 @@ namespace funya1_wpf
             }
         }
 
-        public void Play(MusicInfo music)
+        public void Play(MusicInfo music, int volume = NormalVolume)
         {
             Stop();
             if (!Options.IsEnabled || music.FilePath == "" || !File.Exists(music.FilePath))
             {
                 return;
             }
+            Volume = volume;
+            ActualVolume = volume;
             Player.Open(new Uri(music.FilePath));
+            Player.Volume = Volume / 100.0;
             Player.Play();
             Playing = music;
         }
@@ -43,6 +51,24 @@ namespace funya1_wpf
         {
             Player.Stop();
             Playing = null;
+        }
+
+        public void OnFrame()
+        {
+            if (Playing == null)
+            {
+                return;
+            }
+            if (ActualVolume > Volume)
+            {
+                ActualVolume--;
+                Player.Volume = ActualVolume / 100.0;
+            }
+            else if (ActualVolume < Volume)
+            {
+                ActualVolume++;
+                Player.Volume = ActualVolume / 100.0;
+            }
         }
     }
 }


### PR DESCRIPTION
- `FormMain.xaml.cs` に `MusicFadeTimer` を追加し、コンストラクタ内で初期化および `Tick` イベントハンドラを設定
- `MusicFadeTimer` の `Tick` イベントハンドラでゲーム状態に応じた音楽ボリューム変更ロジックを追加
- `Music` クラスに `Volume` と `ActualVolume` プロパティを追加
- `Music` クラスに `NormalVolume` と `SleepVolume` の定数を追加
- `Music` クラスの `Play` メソッドにボリューム設定引数を追加
- `Music` クラスに `OnFrame` メソッドを追加し、`ActualVolume` を `Volume` に近づける処理を実装
- `FormMain.xaml.cs` の `OnMessageClose` デリゲート内で音楽再生時にボリュームを設定するよう変更

resolve #13