### PR TITLE
ステージメーカー：タイル描画と位置更新の条件を改善

### DIFF
--- a/funya1_wpf/FormEditor.xaml.cs
+++ b/funya1_wpf/FormEditor.xaml.cs
@@ -156,26 +156,35 @@ namespace funya1_wpf
                     switch (editMode)
                     {
                         case EditMode.Chip:
-                            SelectedMap.Value.Data[x, y] = selectedNumber;
-                            var dv = new DrawingVisual();
-                            using (var dc = dv.RenderOpen())
+                            if (SelectedMap.Value.Data[x, y] != selectedNumber)
                             {
-                                SelectedMap.Value.DrawTile(StageData.croppedBitmaps, dc, x, y);
+                                SelectedMap.Value.Data[x, y] = selectedNumber;
+                                var dv = new DrawingVisual();
+                                using (var dc = dv.RenderOpen())
+                                {
+                                    SelectedMap.Value.DrawTile(StageData.croppedBitmaps, dc, x, y);
+                                }
+                                terrainImage.Render(dv);
                             }
-                            terrainImage.Render(dv);
                             break;
                         case EditMode.Mine:
-                            if (IsValidMinePosition(x, y))
+                            if (SelectedMap.Value.StartX != x || SelectedMap.Value.StartY != y)
                             {
-                                SelectedMap.Value.StartX = x;
-                                SelectedMap.Value.StartY = y;
+                                if (IsValidMinePosition(x, y))
+                                {
+                                    SelectedMap.Value.StartX = x;
+                                    SelectedMap.Value.StartY = y;
+                                }
+                                MoveCharacters();
                             }
-                            MoveCharacters();
                             break;
                         case EditMode.Food:
-                            SelectedMap.Value.Food[selectedNumber].x = x;
-                            SelectedMap.Value.Food[selectedNumber].y = y;
-                            MoveCharacters();
+                            if (SelectedMap.Value.Food[selectedNumber].x != x || SelectedMap.Value.Food[selectedNumber].y != y)
+                            {
+                                SelectedMap.Value.Food[selectedNumber].x = x;
+                                SelectedMap.Value.Food[selectedNumber].y = y;
+                                MoveCharacters();
+                            }
                             break;
                     }
                 }


### PR DESCRIPTION
`SelectedMap.Value.Data[x, y]`の値が`selectedNumber`と異なる場合にのみタイルを描画するように変更しました。また、`EditMode.Mine`と`EditMode.Food`の処理において、位置が変更された場合にのみ関連するプロパティを更新するように改善しました。これにより、無駄な処理を避け、パフォーマンスが向上します。 resolve #59